### PR TITLE
Make android app compatible with QT 5.10 and C++14

### DIFF
--- a/AndroidRemoteControl/History.cpp
+++ b/AndroidRemoteControl/History.cpp
@@ -25,7 +25,7 @@ void History::push(std::unique_ptr<Action> action)
     if (m_current)
         m_current->save();
     m_backward.push(std::move(m_current));
-    m_forward = {};
+    m_forward = std::stack<std::unique_ptr<Action>>();
     m_current = std::move(action);
     m_current->run();
 }

--- a/AndroidRemoteControl/android/AndroidManifest.xml
+++ b/AndroidRemoteControl/android/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0'?>
+<?xml version="1.0"?>
 <manifest android:versionCode="7" android:installLocation="auto" package="org.kde.kphotoalbum" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.0.0">
     <application android:label="KPhotoAlbum" android:hardwareAccelerated="true" android:name="org.qtproject.qt5.android.bindings.QtApplication" android:icon="@drawable/icon">
         <activity android:screenOrientation="unspecified" android:label="@string/app_name" android:name="org.qtproject.qt5.android.bindings.QtActivity" android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|locale|fontScale|keyboard|keyboardHidden|navigation">
@@ -31,7 +31,7 @@
             <!-- Splash screen -->
         </activity>
     </application>
-    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="14"/>
+    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="16"/>
     <supports-screens android:largeScreens="true" android:normalScreens="true" android:anyDensity="true" android:smallScreens="true"/>
     <!-- %%INSERT_PERMISSIONS -->
     <!-- %%INSERT_FEATURES -->


### PR DESCRIPTION
Hi,

The app currently available in Google Play does not properly work with the latest kphotoalbum since it's based on version 4.7. A user has even added a 1-star review because of that.

I am now using the latest version in my phone but I had to bump the minimum Android SDK version to 16 (using QT 5.10) and change an empty stack initialization due changes in C++14. I am unsure if using C++14 conforms with your expectations, or if you prefer not to merge that change.

Regards,
Jordi Nadal